### PR TITLE
Fix build warnings and add JVM native access flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.experimental.enableArtProfiles=true
 org.gradle.unsafe.configuration-cache=false
 org.gradle.configuration-cache.problems=warn
 org.gradle.daemon=false
-org.gradle.jvmargs=-Xmx512m -Xms128m -XX:MaxMetaspaceSize=512m -XX:+UseSerialGC -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx512m -Xms128m -XX:MaxMetaspaceSize=512m -XX:+UseSerialGC -Dfile.encoding=UTF-8 --enable-native-access=ALL-UNNAMED
 
 # CI/CD Optimizations
 org.gradle.logging.level=lifecycle


### PR DESCRIPTION
This commit addresses a build warning related to restricted method access in newer JDKs.

- **Added `--enable-native-access` flag:** Modified `gradle.properties` to include the `--enable-native-access=ALL-UNNAMED` JVM argument. This is necessary to allow Gradle's internal components to function correctly with recent Java versions that have stricter access controls.

This change builds upon the previous fixes for compilation errors and merge conflicts. The project should now build cleanly without warnings in the target environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JVM settings to enable native access for improved compatibility with certain features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->